### PR TITLE
🔀 :: (#27) - make design system allergy card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /.idea/deploymentTargetDropDown.xml
 /.idea/gradle.xml
 /.idea/misc.xml
+/.idea/inspectionProfiles/Project_Default.xml
 .DS_Store
 /build
 /captures

--- a/core/designsystem/src/main/java/khs/onmi/core/designsystem/component/Card.kt
+++ b/core/designsystem/src/main/java/khs/onmi/core/designsystem/component/Card.kt
@@ -2,12 +2,16 @@ package khs.onmi.core.designsystem.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
@@ -31,6 +35,7 @@ import khs.onmi.core.designsystem.theme.ONMITheme
 fun AllergiesCard(
     modifier: Modifier = Modifier,
     isSelected: Boolean,
+    itemNumber: Int,
     allergyName: String,
     allergyIcon: @Composable () -> Unit,
     onItemClick: () -> Unit,
@@ -43,20 +48,37 @@ fun AllergiesCard(
             colors = CardDefaults.cardColors(containerColor = color.CardBackgroundSecondary),
             onClick = onItemClick
         ) {
-            Column(
-                modifier = Modifier.fillMaxHeight(),
-                verticalArrangement = Arrangement.Center
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.padding(start = 20.dp)
+            Box(modifier = Modifier.fillMaxSize()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .align(Alignment.CenterStart),
+                    verticalArrangement = Arrangement.Center
                 ) {
-                    allergyIcon()
-                    Spacer(modifier = Modifier.width(8.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(start = 20.dp)
+                    ) {
+                        allergyIcon()
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = allergyName,
+                            style = typography.Body3,
+                            color = if (isSelected) color.TextPrimary else color.UnselectedPrimary
+                        )
+                    }
+                }
+                Box(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .align(Alignment.TopEnd)
+                        .offset(x = (-8).dp, y = 8.dp)
+                ) {
                     Text(
-                        text = allergyName,
+                        text = itemNumber.toString(),
                         style = typography.Body3,
-                        color = if (isSelected) color.TextPrimary else color.UnselectedPrimary
+                        color = if (isSelected) color.TextPrimary else color.UnselectedPrimary,
+                        modifier = Modifier.align(Alignment.Center)
                     )
                 }
             }
@@ -76,6 +98,7 @@ fun AllergiesCardPre() {
             .width(167.dp)
             .height(96.dp),
         isSelected = isSelected,
+        itemNumber = 1,
         allergyName = "달걀",
         allergyIcon = {
             AllergiesEggIcon(isItemSelected = isSelected)

--- a/core/designsystem/src/main/java/khs/onmi/core/designsystem/component/Card.kt
+++ b/core/designsystem/src/main/java/khs/onmi/core/designsystem/component/Card.kt
@@ -1,6 +1,7 @@
 package khs.onmi.core.designsystem.component
 
-import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,8 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,13 +24,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import khs.onmi.core.designsystem.icon.AllergiesEggIcon
 import khs.onmi.core.designsystem.modifier.addBounceEffect
+import khs.onmi.core.designsystem.modifier.onmiClickable
 import khs.onmi.core.designsystem.theme.ONMITheme
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AllergiesCard(
     modifier: Modifier = Modifier,
@@ -42,46 +43,49 @@ fun AllergiesCard(
     onItemClick: () -> Unit,
 ) {
     ONMITheme { color, typography ->
-        Card(
-            modifier = modifier.addBounceEffect(),
-            shape = RoundedCornerShape(16.dp),
-            border = BorderStroke(2.dp, color.Black).takeIf { isSelected },
-            colors = CardDefaults.cardColors(containerColor = color.CardBackgroundSecondary),
-            onClick = onItemClick
+        Box(
+            modifier = modifier
+                .addBounceEffect()
+                .onmiClickable(rippleEnabled = false, onClick = onItemClick)
+                .clip(RoundedCornerShape(16.dp))
+                .background(color.CardBackgroundSecondary)
+                .border(
+                    2.dp,
+                    if (isSelected) color.Black else Color.Transparent,
+                    RoundedCornerShape(16.dp)
+                )
         ) {
-            Box(modifier = Modifier.fillMaxSize()) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .align(Alignment.CenterStart),
-                    verticalArrangement = Arrangement.Center
+            Column(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .align(Alignment.CenterStart),
+                verticalArrangement = Arrangement.Center
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(start = 20.dp)
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(start = 20.dp)
-                    ) {
-                        allergyIcon()
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = allergyName,
-                            style = typography.Body3,
-                            color = if (isSelected) color.TextPrimary else color.UnselectedPrimary
-                        )
-                    }
-                }
-                Box(
-                    modifier = Modifier
-                        .size(24.dp)
-                        .align(Alignment.TopEnd)
-                        .offset(x = (-8).dp, y = 8.dp)
-                ) {
+                    allergyIcon()
+                    Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = itemNumber.toString(),
+                        text = allergyName,
                         style = typography.Body3,
-                        color = if (isSelected) color.TextPrimary else color.UnselectedPrimary,
-                        modifier = Modifier.align(Alignment.Center)
+                        color = if (isSelected) color.TextPrimary else color.UnselectedPrimary
                     )
                 }
+            }
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .align(Alignment.TopEnd)
+                    .offset(x = (-8).dp, y = 8.dp)
+            ) {
+                Text(
+                    text = itemNumber.toString(),
+                    style = typography.Body3,
+                    color = if (isSelected) color.TextPrimary else color.UnselectedPrimary,
+                    modifier = Modifier.align(Alignment.Center)
+                )
             }
         }
     }

--- a/core/designsystem/src/main/java/khs/onmi/core/designsystem/component/Card.kt
+++ b/core/designsystem/src/main/java/khs/onmi/core/designsystem/component/Card.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import khs.onmi.core.designsystem.icon.AllergiesEggIcon
+import khs.onmi.core.designsystem.modifier.addBounceEffect
 import khs.onmi.core.designsystem.theme.ONMITheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -42,7 +43,7 @@ fun AllergiesCard(
 ) {
     ONMITheme { color, typography ->
         Card(
-            modifier = modifier,
+            modifier = modifier.addBounceEffect(),
             shape = RoundedCornerShape(16.dp),
             border = BorderStroke(2.dp, color.Black).takeIf { isSelected },
             colors = CardDefaults.cardColors(containerColor = color.CardBackgroundSecondary),
@@ -99,7 +100,7 @@ fun AllergiesCardPre() {
             .height(96.dp),
         isSelected = isSelected,
         itemNumber = 1,
-        allergyName = "달걀",
+        allergyName = "난류",
         allergyIcon = {
             AllergiesEggIcon(isItemSelected = isSelected)
         },

--- a/core/designsystem/src/main/java/khs/onmi/core/designsystem/component/Card.kt
+++ b/core/designsystem/src/main/java/khs/onmi/core/designsystem/component/Card.kt
@@ -1,0 +1,87 @@
+package khs.onmi.core.designsystem.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import khs.onmi.core.designsystem.icon.AllergiesEggIcon
+import khs.onmi.core.designsystem.theme.ONMITheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AllergiesCard(
+    modifier: Modifier = Modifier,
+    isSelected: Boolean,
+    allergyName: String,
+    allergyIcon: @Composable () -> Unit,
+    onItemClick: () -> Unit,
+) {
+    ONMITheme { color, typography ->
+        Card(
+            modifier = modifier,
+            shape = RoundedCornerShape(16.dp),
+            border = BorderStroke(2.dp, color.Black).takeIf { isSelected },
+            colors = CardDefaults.cardColors(containerColor = color.CardBackgroundSecondary),
+            onClick = onItemClick
+        ) {
+            Column(
+                modifier = Modifier.fillMaxHeight(),
+                verticalArrangement = Arrangement.Center
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(start = 20.dp)
+                ) {
+                    allergyIcon()
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = allergyName,
+                        style = typography.Body3,
+                        color = if (isSelected) color.TextPrimary else color.UnselectedPrimary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun AllergiesCardPre() {
+    var isSelected by remember {
+        mutableStateOf(false)
+    }
+
+    AllergiesCard(
+        modifier = Modifier
+            .width(167.dp)
+            .height(96.dp),
+        isSelected = isSelected,
+        allergyName = "달걀",
+        allergyIcon = {
+            AllergiesEggIcon(isItemSelected = isSelected)
+        },
+        onItemClick = {
+            isSelected = !isSelected
+        }
+    )
+}

--- a/core/designsystem/src/main/java/khs/onmi/core/designsystem/modifier/BounceClickEffect.kt
+++ b/core/designsystem/src/main/java/khs/onmi/core/designsystem/modifier/BounceClickEffect.kt
@@ -1,0 +1,41 @@
+package khs.onmi.core.designsystem.modifier
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+
+enum class ButtonState { Pressed, Idle }
+
+fun Modifier.addBounceEffect() = composed {
+    var buttonState by remember { mutableStateOf(ButtonState.Idle) }
+    val scale by animateFloatAsState(if (buttonState == ButtonState.Pressed) 0.70f else 1f, label = "")
+
+    this.graphicsLayer {
+        scaleX = scale
+        scaleY = scale
+    }.clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = null,
+        onClick = {}
+    ).pointerInput(buttonState) {
+        awaitPointerEventScope {
+            buttonState = if (buttonState == ButtonState.Pressed) {
+                waitForUpOrCancellation()
+                ButtonState.Idle
+            } else {
+                awaitFirstDown(false)
+                ButtonState.Pressed
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/java/khs/onmi/core/designsystem/modifier/BounceClickEffect.kt
+++ b/core/designsystem/src/main/java/khs/onmi/core/designsystem/modifier/BounceClickEffect.kt
@@ -16,9 +16,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 
 enum class ButtonState { Pressed, Idle }
 
-fun Modifier.addBounceEffect() = composed {
+fun Modifier.addBounceEffect(bouncingDegree: Float = 0.85f) = composed {
     var buttonState by remember { mutableStateOf(ButtonState.Idle) }
-    val scale by animateFloatAsState(if (buttonState == ButtonState.Pressed) 0.70f else 1f, label = "")
+    val scale by animateFloatAsState(if (buttonState == ButtonState.Pressed) bouncingDegree else 1f, label = "")
 
     this.graphicsLayer {
         scaleX = scale

--- a/core/designsystem/src/main/java/khs/onmi/core/designsystem/modifier/Clickable.kt
+++ b/core/designsystem/src/main/java/khs/onmi/core/designsystem/modifier/Clickable.kt
@@ -1,0 +1,24 @@
+package khs.onmi.core.designsystem.modifier
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.unit.Dp
+
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.onmiClickable(
+    rippleEnabled: Boolean = true,
+    bounded: Boolean = true,
+    radius: Dp = Dp.Unspecified,
+    onClick: () -> Unit
+) = composed {
+    combinedClickable(
+        onClick = onClick,
+        interactionSource = remember { MutableInteractionSource() },
+        indication = if (rippleEnabled) rememberRipple(bounded = bounded, radius = radius) else null
+    )
+}


### PR DESCRIPTION
## 💡 개요
- 디자인 시스템 알러지 카드 컴포넌트 제작

## 📃 작업내용
white theme

https://github.com/khs3994/TodayWhat-Aos/assets/80810303/f274f8d4-9ce9-499d-a405-68893534bc36


dark theme

https://github.com/khs3994/TodayWhat-Aos/assets/80810303/22b43e78-71de-43ea-b561-94ea0b77c69f

- component에 bounce effect를 추가하는 addBounceEffect() 확장함수를 제작하였습니다.
- click able의 ripple에 대해 커스텀을 진행할 수 있는 onmiClickable을 제작하였습니다.
